### PR TITLE
Add a basic CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+# Language flags.
+language: rust
+
+# OS matrix.
+os:
+  - linux
+  - osx
+  - windows
+
+# Version matrix.
+rust:
+  - stable
+  - beta
+  - nightly
+
+# Cargo caching.
+cache:
+  cargo: true
+
+# Matrix modifications.
+matrix:
+
+  # Failures to allow.
+  allow_failures:
+    - rust: nightly
+
+  # Additional builds.
+  include:
+
+    # Clippy linting.
+    - rust: stable
+      os: linux
+      script:
+        - rustup component add clippy
+        - cargo clippy --all --profile test
+
+    # Format linting.
+    - rust: stable
+      os: linux
+      script:
+        - rustup component add rustfmt
+        - cargo fmt --all -- --check


### PR DESCRIPTION
This fixes #20.

This PR adds a basic [TravisCI](https://travis-ci.org/) configuration which will run tests and validate lints/formatting based on the general Rust standards. I can't test it specifically on this library, because the owner will have to enable it in TravisCI :) 

If you want anything changed and/or added, please let me know!  